### PR TITLE
Add more details about error message

### DIFF
--- a/src/browser/browserHttpClientSession.ts
+++ b/src/browser/browserHttpClientSession.ts
@@ -59,7 +59,7 @@ export class BrowserHttpClientSession implements IHttpClientSession {
     this._promise = new Promise<IResponse>((resolve, reject) => {
       this._xhr.upload.onprogress = FunctionUtils.throttle((e: ProgressEvent) => this.onUploadProgress.push(e), 1000);
       this._xhr.onprogress = FunctionUtils.throttle((e: ProgressEvent) => this.onDownloadProgress.push(e), 1000);
-      this._xhr.onerror = e => reject(new Error(`Failed request to ${request.url.toString()}`));
+      this._xhr.onerror = e => reject(new Error(`Failed request to ${request.url.toString()} reason: ${e.message}`));
       this._xhr.ontimeout = e => reject(new Error(`Request to ${request.url.toString()} timed out`));
       this._xhr.onload = e => {
         resolve(new BrowserResponse(this._xhr));


### PR DESCRIPTION
Sometimes it is not enough to have a message like "Something went wrong" we need to have more details about errors that occurred during request session    